### PR TITLE
Fixed compile error with azeroth latest commit

### DIFF
--- a/src/Chat_Enhanced.cpp
+++ b/src/Chat_Enhanced.cpp
@@ -34,15 +34,15 @@ void Chat_Enhanced_World::OnBeforeConfigLoad(bool reload)
     {
         Field* fields = qResult->Fetch();
 
-        std::string emoji = Acore::StringFormatFmt(":{}:", fields[0].Get<std::string>());
-        std::string resource = Acore::StringFormatFmt("|T{}|t", fields[1].Get<std::string>());
+        std::string emoji = Acore::StringFormat(":{}:", fields[0].Get<std::string>());
+        std::string resource = Acore::StringFormat("|T{}|t", fields[1].Get<std::string>());
 
         ceEmojiMap.emplace(emoji, resource);
         count++;
     }
     while (qResult->NextRow());
 
-    LOG_INFO("module", Acore::StringFormatFmt(">> Loaded '{}' emojis.", count));
+    LOG_INFO("module", Acore::StringFormat(">> Loaded '{}' emojis.", count));
 }
 
 Player* Chat_Enhanced_Player::FindPlayerByName(const std::string& name)


### PR DESCRIPTION
## Changes Proposed:

- Acore::StringFormatFmt to Acore::StringFormat in Chat_Enhanced.cpp at lines 37, 38 and 45

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

 - Error C2039	'StringFormatFmt': is not a member of  'Acore' modules
 - Error C3861	'StringFormatFmt': identifier not found modules
 - With the following change the core successfully builds. I have tested the emotes and @playername in game to verify fix. Windows 11 Pro.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Change Acore::StringFormatFmt to Acore::StringFormat in Chat_Enhanced.cpp 
2. Recompile core with latest azerothcore commit, and run included world sql file.
3. Test a random emote and @playername in game.
